### PR TITLE
Improve DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Una tienda web completa desarrollada en PHP con MySQL, inspirada en el diseño m
 
 3. **Configurar la conexión**:
    - Abre `config/database.php`
-   - Verifica que los datos de conexión sean correctos:
+   - Verifica que los datos de conexión sean correctos o define las variables de
+     entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` para personalizar la
+     conexión sin modificar el archivo:
      ```php
      private $host = 'localhost';
      private $dbname = 'alquimia_technologic';

--- a/config/database.php
+++ b/config/database.php
@@ -1,10 +1,22 @@
 <?php
 class Database {
-    private $host = 'localhost';
-    private $dbname = 'alquimia_technologic';
-    private $username = 'root';
-    private $password = '';
+    /**
+     * Parámetros de conexión. Permiten sobrescribir valores mediante variables
+     * de entorno para facilitar la configuración en distintos entornos de
+     * ejecución (desarrollo, pruebas, producción).
+     */
+    private $host;
+    private $dbname;
+    private $username;
+    private $password;
     private $pdo;
+
+    public function __construct() {
+        $this->host = getenv('DB_HOST') ?: (defined('DB_HOST') ? DB_HOST : 'localhost');
+        $this->dbname = getenv('DB_NAME') ?: (defined('DB_NAME') ? DB_NAME : 'alquimia_technologic');
+        $this->username = getenv('DB_USER') ?: (defined('DB_USER') ? DB_USER : 'root');
+        $this->password = getenv('DB_PASS') ?: (defined('DB_PASS') ? DB_PASS : '');
+    }
     
     public function connect() {
         try {


### PR DESCRIPTION
## Summary
- support environment variables in `Database` class
- document DB_HOST/DB_NAME/DB_USER/DB_PASS environment variables in README

## Testing
- `php -l config/database.php`
- `php -l README.md`
- `php test_system.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6875aadb055483268ad72c9290742b5a