### PR TITLE
Fix missing toggleFeatured function

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -243,6 +243,25 @@ class Product {
             return false;
         }
     }
+
+    // Alternar estado de destacado
+    public function toggleFeatured($productId) {
+        try {
+            $sql = "UPDATE products SET is_featured = IF(is_featured = 1, 0, 1) WHERE id = ?";
+            $stmt = $this->db->prepare($sql);
+            $stmt->execute([$productId]);
+
+            if ($stmt->rowCount()) {
+                $stmt = $this->db->prepare("SELECT is_featured FROM products WHERE id = ?");
+                $stmt->execute([$productId]);
+                return (int)$stmt->fetchColumn();
+            }
+
+            return false;
+        } catch(PDOException $e) {
+            return false;
+        }
+    }
     
     // Obtener productos relacionados
     public function getRelatedProducts($categoryId, $excludeId, $limit = 4) {


### PR DESCRIPTION
## Summary
- add toggleFeatured method in Product class to toggle the featured flag

## Testing
- `php -l classes/Product.php`
- `for f in $(find . -name '*.php'); do php -l "$f"; done` *(no syntax errors)*
- `php test_system.php` *(fails: No such file or directory for DB)*

------
https://chatgpt.com/codex/tasks/task_b_6875c6355c44832682e7b9a0aaf9a0f3